### PR TITLE
Allow for skipping waiting for CRDs to be created.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ No modules.
 | <a name="input_tetragon_helm_version"></a> [tetragon\_helm\_version](#input\_tetragon\_helm\_version) | The version of the Tetragon Helm chart to install. | `string` | n/a | yes |
 | <a name="input_tetragon_namespace"></a> [tetragon\_namespace](#input\_tetragon\_namespace) | The namespace in which to install Tetragon. | `string` | `"kube-system"` | no |
 | <a name="input_tetragon_tracingpolicy_directory"></a> [tetragon\_tracingpolicy\_directory](#input\_tetragon\_tracingpolicy\_directory) | Path to the directory where TracingPolicy files are stored which should automatically be applied. The directory can contain one or multiple valid TracingPoliciy YAML files. | `string` | `""` | no |
+| <a name="input_wait_for_tetragon_crds"></a> [wait\_for\_tetragon\_crds](#input\_wait\_for\_tetragon\_crds) | Whether to wait for the Tetragon CRDs to be created before proceeding with the post-install script. | `bool` | `true` | no |
 
 ### Outputs
 

--- a/locals.tf
+++ b/locals.tf
@@ -12,6 +12,7 @@ locals {
     KUBECONFIG                         = var.path_to_kubeconfig_file                                                                  // The path to the kubeconfig file that will be created and output.
     PRE_TETRAGON_INSTALL_SCRIPT        = var.pre_tetragon_install_script != "" ? base64encode(var.pre_tetragon_install_script) : ""   // The script to execute before installing Tetragon.
     POST_TETRAGON_INSTALL_SCRIPT       = var.post_tetragon_install_script != "" ? base64encode(var.post_tetragon_install_script) : "" // The script to execute after installing Tetragon.
+    WAIT_FOR_TETRAGON_CRDS             = var.wait_for_tetragon_crds
   }
   provisioner_path        = "${abspath(path.module)}/scripts/provisioner.sh"
   tp_deployer_environment = merge(var.extra_tp_deployer_environment_variables, local.tp_deployer_environment_variables) // The full set of environment variables passed to the TracingPolicy deployment script.

--- a/scripts/provisioner.sh
+++ b/scripts/provisioner.sh
@@ -37,21 +37,25 @@ else
   rm -f tmp1
 fi
 
-# Wait for the Tetragon CRDs to be available before exiting. They should be installed by the Tetragon Operator.
-TETRAGON_CRD_AVAILABILITY_COUNT=1
-set +e
-until kubectl get crd tracingpolicies.cilium.io
-do
-  if [[ ${TETRAGON_CRD_AVAILABILITY_COUNT} -gt 60 ]];
-  then
-    echo "Tetragon CRDs are not available. Check Tetragon installation."
-    exit 1
-  else
-    TETRAGON_CRD_AVAILABILITY_COUNT=$((TETRAGON_CRD_AVAILABILITY_COUNT+1))
-    sleep 1
-  fi
-done
-set -e
+# If asked to, wait for the Tetragon CRDs to be available before proceeding.
+# By default they are installed by the Tetragon operator, but it is now possible to install them out-of-band.
+if [[ "${WAIT_FOR_TETRAGON_CRDS}" == "true" ]];
+then
+  TETRAGON_CRD_AVAILABILITY_COUNT=1
+  set +e
+  until kubectl get crd tracingpolicies.cilium.io
+  do
+    if [[ ${TETRAGON_CRD_AVAILABILITY_COUNT} -gt 60 ]];
+    then
+      echo "Tetragon CRDs are not available. Check Tetragon installation."
+      exit 1
+    else
+      TETRAGON_CRD_AVAILABILITY_COUNT=$((TETRAGON_CRD_AVAILABILITY_COUNT+1))
+      sleep 1
+    fi
+  done
+  set -e
+fi
 
 # Run any post-install script we may have been provided with.
 if [[ "${POST_TETRAGON_INSTALL_SCRIPT}" != "" ]];

--- a/variables.tf
+++ b/variables.tf
@@ -72,3 +72,9 @@ variable "post_tetragon_install_script" {
   description = "A script to be run right after installing Tetragon."
   type        = string
 }
+
+variable "wait_for_tetragon_crds" {
+  default     = true
+  description = "Whether to wait for the Tetragon CRDs to be created before proceeding with the post-install script."
+  type        = bool
+}


### PR DESCRIPTION
It has been possible for a while to install the Tetragon CRDs "out-of-band" (see [here](https://github.com/cilium/tetragon/blob/v1.1.2/install/kubernetes/tetragon/values.yaml#L336-L341)). This PR adds support for bypassing the waiting loop so that the post-install script can be executed right away.